### PR TITLE
Fix for GDM redirect issue https://github.com/SAP/xf-addons/issues/12…

### DIFF
--- a/api-registration-job/main.go
+++ b/api-registration-job/main.go
@@ -186,7 +186,7 @@ func (r registrationApp) getRegisteredAPIs() []API {
 }
 
 func (r registrationApp) isAPIActive(path string) (bool, error) {
-	url := r.SystemURL + "/" + path
+	url := r.SystemURL + "/" + path + "/"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
…. The API URLs need to have a '/' on the end of them otherwise a redirect is issued (307) which the go http client is not following correctly (500 error).