### PR TITLE
Update litmos event gateway

### DIFF
--- a/litmos-event-gw/internal/model/events/events.go
+++ b/litmos-event-gw/internal/model/events/events.go
@@ -3,6 +3,7 @@ package events
 import (
 	"github.com/gofrs/uuid"
 	"github.com/kyma-incubator/connector-tools/litmos-event-gw/internal/config"
+	"time"
 )
 
 type KymaEvent struct {
@@ -30,7 +31,7 @@ func Map(litmosEvent *LitmosEvent) *KymaEvent {
 		SourceID:         config.GlobalConfig.BaseTopic,
 		EventType:        eventType,
 		EventTypeVersion: "v1",
-		EventTime:        litmosEvent.Created,
+		EventTime:        time.Now().Format(time.RFC3339),
 		Data:             litmosEvent.Data,
 		EventID:          eventId,
 	}

--- a/litmos-event-gw/internal/router/router.go
+++ b/litmos-event-gw/internal/router/router.go
@@ -18,7 +18,7 @@ func New() http.Handler {
 	r := mux.NewRouter()
 	ep := handlers.NewEventPublisher()
 
-	r.HandleFunc("/events", ep.EventHandler()).Methods(http.MethodPost)
+	r.HandleFunc("/", ep.EventHandler()).Methods(http.MethodPost)
 
 	return &Rtr{
 		Handler:        applyLogging(r),

--- a/litmos-event-gw/main_test.go
+++ b/litmos-event-gw/main_test.go
@@ -64,7 +64,7 @@ func TestEventIngestionSuccess(t *testing.T) {
 	}
 	b, _ := json.Marshal(le)
 
-	req, err := http.NewRequest(http.MethodPost, "http://localhost:8080/events", bytes.NewReader(b))
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:8080/", bytes.NewReader(b))
 	resp, err := httpClient.Do(req)
 
 	g.Expect(err).Should(BeNil())


### PR DESCRIPTION
- Use the RFC3339 time format for event-time
- Make the event ingestion for default path